### PR TITLE
Renamed sym_save to str_intern to better describe it

### DIFF
--- a/include/context.h
+++ b/include/context.h
@@ -3,7 +3,6 @@
 
 #include "env.h"
 #include "palloc.h"
-#include "rb_tree.h"
 
 #define CTX_POOL(ctx) ((ctx)->node_pool)
 

--- a/include/env.h
+++ b/include/env.h
@@ -10,12 +10,10 @@ typedef struct env Env;
 Env *env_create (void);
 void env_destroy (Env *env);
 void env_leave_frame (Env **frame);
-// access
 bool env_has_key (Env *frame, const char *key);
 void *env_lookup (Env *frame, const char *key);
 bool env_let (Env *frame, const char *key, void *val);
 bool env_set (Env *frame, const char *key, void *val);
-// frames
 void env_enter_frame (Env **frame);
 void env_leave_frame (Env **frame);
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -1,7 +1,12 @@
 #ifndef _PARSER_H_
 #define _PARSER_H_
 
+#include <stdio.h>
+
+#include "context.h"
+#include "types.h"
+
 bool parser_buf (const char *input, Node **ast_head, Context *ctx);
-bool parser_stream (FILE *restrict in, Node **ast_head, Context *ctx);
+bool parser_stream (FILE *instrm, Node **ast_head, Context *ctx);
 
 #endif

--- a/include/rb_tree.h
+++ b/include/rb_tree.h
@@ -1,8 +1,9 @@
 #ifndef RB_TREE_H
 #define RB_TREE_H
 
-#include "stack.h"
 #include <stdlib.h>
+
+#include "stack.h"
 
 #define RB_KEY(n) ((n)->key)
 #define RB_KEY_LEN(n) ((n)->key_len)

--- a/include/str_intern.h
+++ b/include/str_intern.h
@@ -12,6 +12,6 @@
 #define SYM_SAVE_BUMP_SIZE 4096
 #endif
 
-const char *sym_save (const char *s, size_t s_len);
+const char *str_intern (const char *s, size_t s_len);
 
 #endif

--- a/src/flex.l
+++ b/src/flex.l
@@ -8,7 +8,7 @@
 #include <string.h>
 
 #include "bison.h"
-#include "sym_save.h"
+#include "str_intern.h"
 %}
 
 NL       \r?\n
@@ -42,7 +42,7 @@ ID       [a-zA-Z_][a-zA-Z0-9_]*
                       return LAMBDA;
 
                     yylval.symbol.len = yyleng;
-                    yylval.symbol.str = sym_save (yytext, yyleng);
+                    yylval.symbol.str = str_intern (yytext, yyleng);
 
                     if (!strncasecmp ("IF", yytext, yyleng + 1))
                       return IF;
@@ -50,7 +50,7 @@ ID       [a-zA-Z_][a-zA-Z0-9_]*
                     return SYMBOL;
                   }
   [+\-*/><]       {
-                    yylval.symbol.str = sym_save (yytext, yyleng);
+                    yylval.symbol.str = str_intern (yytext, yyleng);
                     yylval.symbol.len = yyleng;
                     return SYMBOL;
                   }

--- a/src/parser.c
+++ b/src/parser.c
@@ -19,9 +19,9 @@ parser_buf (const char *input, Node **ast_head, Context *ctx)
 }
 
 bool
-parser_stream (FILE *restrict in, Node **ast_head, Context *ctx)
+parser_stream (FILE *instrm, Node **ast_head, Context *ctx)
 {
-  yyset_in (in);
+  yyset_in (instrm);
 
   int status = yyparse (ast_head, ctx);
 

--- a/src/repl.c
+++ b/src/repl.c
@@ -60,9 +60,9 @@ int
 lispm_repl (Context *ctx)
 {
   Node *progn = NULL;
-  rl_init ();
-
   char input[RL_BUF_SIZ];
+
+  rl_init ();
 
   for (;;)
     {

--- a/src/str_intern.c
+++ b/src/str_intern.c
@@ -5,7 +5,7 @@
 
 #include "palloc.h"
 #include "safe_str.h"
-#include "sym_save.h"
+#include "str_intern.h"
 
 typedef struct BumpPool
 {
@@ -15,7 +15,7 @@ typedef struct BumpPool
 } BumpPool;
 
 static rb_node *root = NULL;
-static bool sym_saved = false;
+static bool str_internd = false;
 static Pool *pool = NULL;
 static BumpPool *bump_pool = NULL;
 
@@ -52,7 +52,7 @@ bump_pool_strndup (const char *s, size_t len)
 }
 
 static void
-sym_save_init (void)
+str_intern_init (void)
 {
   bump_pool = xalloc_bump_pool ();
   pool = pool_init (SYMTAB_POOL_CAPACITY, sizeof (rb_node));
@@ -60,12 +60,12 @@ sym_save_init (void)
 
 // TODO: max symbol size/limit
 const char *
-sym_save (const char *s, size_t len)
+str_intern (const char *s, size_t len)
 {
-  if (!sym_saved)
+  if (!str_internd)
     {
-      sym_saved = true;
-      sym_save_init ();
+      str_internd = true;
+      str_intern_init ();
     }
 
   rb_node *node = rb_lookup (root, s, len);

--- a/test/test_palloc.c
+++ b/test/test_palloc.c
@@ -51,12 +51,9 @@ Suite *
 palloc_suite (void)
 {
   Suite *s = suite_create ("Palloc");
-
   TCase *tc_core = tcase_create ("Core");
-
   tcase_add_exit_test (tc_core, test_palloc, 1);
   tcase_add_test (tc_core, test_palloc_hier);
-
   suite_add_tcase (s, tc_core);
   return s;
 }

--- a/test/test_str_intern.c
+++ b/test/test_str_intern.c
@@ -2,9 +2,9 @@
 #include <string.h>
 
 #include "rb_tree.h"
-#include "sym_save.h"
+#include "str_intern.h"
 
-static const char *test_sym_save_similar_strings[]
+static const char *test_str_intern_similar_strings[]
     = { "example",   "exomple",  "exampl",    "exampel",  "exampqle",
         "exmple",    "exaple",   "examnple",  "exmaple",  "examplex",
         "exapmle",   "examplor", "exampole",  "xample",   "examplely",
@@ -15,10 +15,10 @@ static const char *test_sym_save_similar_strings[]
         "exawple",   "eximpa",   "examplar",  "eximpyle", "example" };
 
 #define NUM_STRINGS                                                           \
-  ((int)(sizeof (test_sym_save_similar_strings)                               \
-         / sizeof (test_sym_save_similar_strings[0])))
+  ((int)(sizeof (test_str_intern_similar_strings)                             \
+         / sizeof (test_str_intern_similar_strings[0])))
 
-START_TEST (test_sym_save)
+START_TEST (test_str_intern)
 {
   struct
   {
@@ -28,18 +28,19 @@ START_TEST (test_sym_save)
 
   for (int i = 0; i < NUM_STRINGS; ++i)
     {
-      saved[i].len = strlen (test_sym_save_similar_strings[i]);
+      saved[i].len = strlen (test_str_intern_similar_strings[i]);
       saved[i].saved_str
-          = sym_save (test_sym_save_similar_strings[i], saved[i].len);
-      ck_assert_str_eq (saved[i].saved_str, test_sym_save_similar_strings[i]);
+          = str_intern (test_str_intern_similar_strings[i], saved[i].len);
+      ck_assert_str_eq (saved[i].saved_str,
+                        test_str_intern_similar_strings[i]);
     }
 
   for (int i = 0; i < NUM_STRINGS; ++i)
     {
       const char *saved_str
-          = sym_save (test_sym_save_similar_strings[i], saved[i].len);
+          = str_intern (test_str_intern_similar_strings[i], saved[i].len);
       ck_assert_str_eq (saved[i].saved_str, saved_str);
-      ck_assert (saved[i].len == strlen (test_sym_save_similar_strings[i]));
+      ck_assert (saved[i].len == strlen (test_str_intern_similar_strings[i]));
     }
 
   for (int i = 0; i < NUM_STRINGS; ++i)
@@ -47,13 +48,13 @@ START_TEST (test_sym_save)
       for (int j = 0; j < NUM_STRINGS; ++j)
         {
           const char *saved_str_i
-              = sym_save (test_sym_save_similar_strings[i],
-                          strlen (test_sym_save_similar_strings[i]));
+              = str_intern (test_str_intern_similar_strings[i],
+                            strlen (test_str_intern_similar_strings[i]));
           const char *saved_str_j
-              = sym_save (test_sym_save_similar_strings[j],
-                          strlen (test_sym_save_similar_strings[j]));
-          if (strcmp (test_sym_save_similar_strings[i],
-                      test_sym_save_similar_strings[j])
+              = str_intern (test_str_intern_similar_strings[j],
+                            strlen (test_str_intern_similar_strings[j]));
+          if (strcmp (test_str_intern_similar_strings[i],
+                      test_str_intern_similar_strings[j])
               == 0)
             ck_assert_str_eq (saved_str_i, saved_str_j);
           else
@@ -62,8 +63,8 @@ START_TEST (test_sym_save)
                              "Assertion failed: strings equal (\"%s\" == "
                              "\"%s\") for %s and %s",
                              saved_str_i, saved_str_j,
-                             test_sym_save_similar_strings[i],
-                             test_sym_save_similar_strings[j]);
+                             test_str_intern_similar_strings[i],
+                             test_str_intern_similar_strings[j]);
             }
         }
     }
@@ -73,9 +74,9 @@ END_TEST
 Suite *
 str_save_suite (void)
 {
-  Suite *s = suite_create ("Symsave");
+  Suite *s = suite_create ("String Intern");
   TCase *tc_core = tcase_create ("Core");
-  tcase_add_test (tc_core, test_sym_save);
+  tcase_add_test (tc_core, test_str_intern);
   suite_add_tcase (s, tc_core);
   return s;
 }


### PR DESCRIPTION
1. Renamed sym_save to str_intern since that better describes it.
2. Removed unnecessary headers.